### PR TITLE
use fake UA on e621

### DIFF
--- a/nsfw_dl/loaders/e621.py
+++ b/nsfw_dl/loaders/e621.py
@@ -29,4 +29,5 @@ class E621Search(BaseSearchJSON):
     def prepare_url(args):
         """ ... """
         return ("https://e621.net/post/index.json?page=dapi&s="
-                f"post&q=index&tags={args}", {}, {})
+                f"post&q=index&tags={args}", {},
+                {"User-Agent": "Mozilla/5.0 Firefox"})

--- a/nsfw_dl/loaders/e621.py
+++ b/nsfw_dl/loaders/e621.py
@@ -13,7 +13,8 @@ class E621Random:
     def prepare_url(args):
         """ ... """
         type(args)
-        return "https://e621.net/post/random", {}, {}
+        return ("https://e621.net/post/random", {}, 
+                {"User-Agent": "Mozilla/5.0 Firefox"})
 
     @staticmethod
     def get_image(data):


### PR DESCRIPTION
e621 now checks user agents, use "Mozilla/5.0 Firefox" to evade the current checks. Tested to work after a bit of trial and error, should close #6.